### PR TITLE
remove duplicate minus button indicator

### DIFF
--- a/templates/show.html
+++ b/templates/show.html
@@ -36,13 +36,6 @@
             Off
           {% endif %}
           ;
-          Minus Button: 
-          {% if minus == 0%} 
-            On
-          {% elif minus == 1%}
-            Off
-          {% endif %}
-          ;
           Alarm Button: 
           {% if alarmEnabled == 0%} 
             On


### PR DESCRIPTION
There's a duplicate minus button indicator in the show.html page. This pull request fixed this issue.
